### PR TITLE
Imported csrf_exempt from django.views.decorators.csrf rather then from ...

### DIFF
--- a/attachments/views.py
+++ b/attachments/views.py
@@ -1,7 +1,7 @@
 import django.dispatch
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
-from django.contrib.csrf.middleware import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse
 
 from djangohelper.helper import flash_login_required, ajax_login_required, \


### PR DESCRIPTION
...the deprecated django.contrib.csrf.middleware, as this breaks compatibility with django 1.4.

As far as I can see django.views.decorators.csrf.csrf_exempt was added in django 1.2 and as lbforum itself lists django 1.3+ as a requirement I don't see how this would break any backwards compatibility either.
